### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/monti0420/c674856e-71cc-45b9-934f-d99feba580fe/3b941804-70e8-4ecc-a75b-933be50ca7b2/_apis/work/boardbadge/0168dfb0-f65d-4663-98ed-bc3a938524c2)](https://dev.azure.com/monti0420/c674856e-71cc-45b9-934f-d99feba580fe/_boards/board/t/3b941804-70e8-4ecc-a75b-933be50ca7b2/Microsoft.RequirementCategory)
 [![Build status](https://github.com/git/git/workflows/CI/PR/badge.svg)](https://github.com/git/git/actions?query=branch%3Amaster+event%3Apush)
 
 Git - fast, scalable, distributed revision control system


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/monti0420/c674856e-71cc-45b9-934f-d99feba580fe/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.